### PR TITLE
feat: skip_workgroup_check setting to reduce AWS throttling

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ A dbt profile can be configured to run against AWS Athena using the following co
 | aws_secret_access_key | Secret access key of the user performing requests                                        | Optional  | `wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY` |
 | aws_profile_name      | Profile to use from your AWS shared credentials file                                     | Optional  | `my-profile`                               |
 | work_group            | Identifier of Athena workgroup                                                           | Optional  | `my-custom-workgroup`                      |
+| skip_workgroup_check  | Indicates if the WorkGroup check (additional AWS call) can be skipped                    | Optional  | `true`                                     |
 | num_retries           | Number of times to retry a failing query                                                 | Optional  | `3`                                        |
 | num_boto3_retries     | Number of times to retry boto3 requests (e.g. deleting S3 files for materialized tables) | Optional  | `5`                                        |
 | num_iceberg_retries   | Number of times to retry iceberg commit queries to fix ICEBERG_COMMIT_ERROR              | Optional  | `3`                                        |

--- a/dbt/adapters/athena/connections.py
+++ b/dbt/adapters/athena/connections.py
@@ -56,7 +56,7 @@ class AthenaCredentials(Credentials):
     region_name: str
     endpoint_url: Optional[str] = None
     work_group: Optional[str] = None
-    work_group_enforced: Optional[bool] = None
+    skip_workgroup_check: bool = False
     aws_profile_name: Optional[str] = None
     aws_access_key_id: Optional[str] = None
     aws_secret_access_key: Optional[str] = None
@@ -92,7 +92,7 @@ class AthenaCredentials(Credentials):
         return (
             "s3_staging_dir",
             "work_group",
-            "work_group_enforced",
+            "skip_workgroup_check",
             "region_name",
             "database",
             "schema",

--- a/dbt/adapters/athena/connections.py
+++ b/dbt/adapters/athena/connections.py
@@ -56,6 +56,7 @@ class AthenaCredentials(Credentials):
     region_name: str
     endpoint_url: Optional[str] = None
     work_group: Optional[str] = None
+    work_group_enforced: Optional[bool] = None
     aws_profile_name: Optional[str] = None
     aws_access_key_id: Optional[str] = None
     aws_secret_access_key: Optional[str] = None
@@ -91,6 +92,7 @@ class AthenaCredentials(Credentials):
         return (
             "s3_staging_dir",
             "work_group",
+            "work_group_enforced",
             "region_name",
             "database",
             "schema",

--- a/dbt/adapters/athena/impl.py
+++ b/dbt/adapters/athena/impl.py
@@ -242,7 +242,10 @@ class AthenaAdapter(SQLAdapter):
         conn = self.connections.get_thread_connection()
         creds = conn.credentials
 
-        if creds.work_group and creds.work_group_enforced is None:
+        if creds.work_group_enforced is not None:
+            return creds.work_group_enforced
+
+        if creds.work_group:
             work_group = self._get_work_group(creds.work_group)
             output_location = (
                 work_group.get("WorkGroup", {})

--- a/dbt/adapters/athena/impl.py
+++ b/dbt/adapters/athena/impl.py
@@ -79,6 +79,7 @@ class AthenaConfig(AdapterConfig):
 
     Args:
         work_group: Identifier of Athena workgroup.
+        work_group_enforced: Assummed value of the WorkGroup location enforcement.
         s3_staging_dir: S3 location to store Athena query results and metadata.
         external_location: If set, the full S3 path in which the table will be saved.
         partitioned_by: An array list of columns by which the table will be partitioned.
@@ -102,6 +103,7 @@ class AthenaConfig(AdapterConfig):
     """
 
     work_group: Optional[str] = None
+    work_group_enforced: Optional[bool] = None
     s3_staging_dir: Optional[str] = None
     external_location: Optional[str] = None
     partitioned_by: Optional[str] = None
@@ -240,7 +242,7 @@ class AthenaAdapter(SQLAdapter):
         conn = self.connections.get_thread_connection()
         creds = conn.credentials
 
-        if creds.work_group:
+        if creds.work_group and creds.work_group_enforced is None:
             work_group = self._get_work_group(creds.work_group)
             output_location = (
                 work_group.get("WorkGroup", {})

--- a/dbt/adapters/athena/impl.py
+++ b/dbt/adapters/athena/impl.py
@@ -243,7 +243,7 @@ class AthenaAdapter(SQLAdapter):
         creds = conn.credentials
 
         if creds.work_group_enforced is not None:
-            return creds.work_group_enforced
+            return creds.work_group_enforced is True
 
         if creds.work_group:
             work_group = self._get_work_group(creds.work_group)

--- a/dbt/adapters/athena/impl.py
+++ b/dbt/adapters/athena/impl.py
@@ -79,7 +79,7 @@ class AthenaConfig(AdapterConfig):
 
     Args:
         work_group: Identifier of Athena workgroup.
-        work_group_enforced: Assummed value of the WorkGroup location enforcement.
+        skip_workgroup_check: Indicates if the WorkGroup check (additional AWS call) can be skipped.
         s3_staging_dir: S3 location to store Athena query results and metadata.
         external_location: If set, the full S3 path in which the table will be saved.
         partitioned_by: An array list of columns by which the table will be partitioned.
@@ -103,7 +103,7 @@ class AthenaConfig(AdapterConfig):
     """
 
     work_group: Optional[str] = None
-    work_group_enforced: Optional[bool] = None
+    skip_workgroup_check: bool = False
     s3_staging_dir: Optional[str] = None
     external_location: Optional[str] = None
     partitioned_by: Optional[str] = None
@@ -242,10 +242,7 @@ class AthenaAdapter(SQLAdapter):
         conn = self.connections.get_thread_connection()
         creds = conn.credentials
 
-        if creds.work_group_enforced is not None:
-            return creds.work_group_enforced is True
-
-        if creds.work_group:
+        if creds.work_group and not creds.skip_workgroup_check:
             work_group = self._get_work_group(creds.work_group)
             output_location = (
                 work_group.get("WorkGroup", {})

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -71,14 +71,16 @@ class TestAthenaAdapter:
         profile_cfg = {
             "outputs": {
                 "test": {
-                    "type": "athena",
-                    "s3_staging_dir": S3_STAGING_DIR,
-                    "region_name": AWS_REGION,
-                    "database": DATA_CATALOG_NAME,
-                    "work_group": ATHENA_WORKGROUP,
-                    "schema": DATABASE_NAME,
+                    **{
+                        "type": "athena",
+                        "s3_staging_dir": S3_STAGING_DIR,
+                        "region_name": AWS_REGION,
+                        "database": DATA_CATALOG_NAME,
+                        "work_group": ATHENA_WORKGROUP,
+                        "schema": DATABASE_NAME,
+                    },
+                    **settings,
                 }
-                | settings
             },
             "target": "test",
         }

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -39,28 +39,7 @@ from .utils import TestAdapterConversions, config_from_parts_or_dicts, inject_ad
 
 class TestAthenaAdapter:
     def setup_method(self, _):
-        project_cfg = {
-            "name": "X",
-            "version": "0.1",
-            "profile": "test",
-            "project-root": "/tmp/dbt/does-not-exist",
-            "config-version": 2,
-        }
-        profile_cfg = {
-            "outputs": {
-                "test": {
-                    "type": "athena",
-                    "s3_staging_dir": S3_STAGING_DIR,
-                    "region_name": AWS_REGION,
-                    "database": DATA_CATALOG_NAME,
-                    "work_group": ATHENA_WORKGROUP,
-                    "schema": DATABASE_NAME,
-                }
-            },
-            "target": "test",
-        }
-
-        self.config = config_from_parts_or_dicts(project_cfg, profile_cfg)
+        self.config = TestAthenaAdapter._config_from_settings()
         self._adapter = None
         self.used_schemas = frozenset(
             {
@@ -78,6 +57,33 @@ class TestAthenaAdapter:
             self._adapter = AthenaAdapter(self.config, get_context("spawn"))
             inject_adapter(self._adapter, AthenaPlugin)
         return self._adapter
+
+    @staticmethod
+    def _config_from_settings(settings={}):
+        project_cfg = {
+            "name": "X",
+            "version": "0.1",
+            "profile": "test",
+            "project-root": "/tmp/dbt/does-not-exist",
+            "config-version": 2,
+        }
+
+        profile_cfg = {
+            "outputs": {
+                "test": {
+                    "type": "athena",
+                    "s3_staging_dir": S3_STAGING_DIR,
+                    "region_name": AWS_REGION,
+                    "database": DATA_CATALOG_NAME,
+                    "work_group": ATHENA_WORKGROUP,
+                    "schema": DATABASE_NAME,
+                }
+                | settings
+            },
+            "target": "test",
+        }
+
+        return config_from_parts_or_dicts(project_cfg, profile_cfg)
 
     @mock.patch("dbt.adapters.athena.connections.AthenaConnection")
     def test_acquire_connection_validations(self, connection_cls):
@@ -930,6 +936,17 @@ class TestAthenaAdapter:
         mock_aws_service.create_work_group_with_output_location_enforced(ATHENA_WORKGROUP)
         work_group_location_enforced = self.adapter.is_work_group_output_location_enforced()
         assert work_group_location_enforced
+
+    def test_get_work_group_output_location_if_workgroup_check_is_skipepd(self):
+        settings = {
+            "skip_workgroup_check": True,
+        }
+
+        self.config = TestAthenaAdapter._config_from_settings(settings)
+        self.adapter.acquire_connection("dummy")
+
+        work_group_location_enforced = self.adapter.is_work_group_output_location_enforced()
+        assert not work_group_location_enforced
 
     @mock_aws
     def test_get_work_group_output_location_no_location(self, mock_aws_service):


### PR DESCRIPTION
# Description

The adapter performs a GetWorkGroup operation on each thread, which is later cached. When dbt build is started for 10 independent models, it issues 10 AWS requests to get the same information. If dbt is orchestrated via Airflow to run 32 dbt tasks concurrently, it sends 320 GetWorkGroup requests, causing throttling on the AWS side.

This PR introduces a skip_workgroup_check setting, which instructs dbt to skip checking if a WorkGroup contains an enforced output location.

## Checklist

- [x] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [x] You kept your Pull Request small and focused on a single feature or bug fix.
- [x] You added unit testing when necessary
- [x] You added functional testing when necessary
