### PR TITLE
chore: remove trigger on label for functional tests

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -20,7 +20,6 @@ jobs:
   # workflow that is invoked when for PRs with labels 'enable-functional-tests'
   functional-tests-pr:
     name: Functional Tests - PR
-    if: contains(github.event.pull_request.labels.*.name, 'enable-functional-tests')
     uses: ./.github/workflows/functional-tests-workflow.yml
     secrets: inherit
     permissions:


### PR DESCRIPTION
# Description

Now that dbtlabs has taken over, and a proper AWS exists under the scene, we can remove the trigger based on a label for functional tests running on PRs.


## Checklist

- [ ] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [ ] You kept your Pull Request small and focused on a single feature or bug fix.
- [ ] You added unit testing when necessary
- [ ] You added functional testing when necessary
