### PR TITLE
fix: Remove non-current iceberg columns from catalog

### DIFF
--- a/dbt/adapters/athena/impl.py
+++ b/dbt/adapters/athena/impl.py
@@ -1098,7 +1098,7 @@ class AthenaAdapter(SQLAdapter):
         """
         Check if a column is explicitly set as not current. If not, it is considered as current.
         """
-        return col.get("Parameters", {}).get("iceberg.field.current") != "false"
+        return bool(col.get("Parameters", {}).get("iceberg.field.current") != "false")
 
     @available
     def get_columns_in_relation(self, relation: AthenaRelation) -> List[AthenaColumn]:

--- a/tests/functional/adapter/test_docs.py
+++ b/tests/functional/adapter/test_docs.py
@@ -51,7 +51,7 @@ class TestDocsGenerate(BaseDocsGenerate):
     """
 
     @pytest.fixture(scope="class")
-    def expected_catalog(self, project, profile_user):
+    def expected_catalog(self, project):
         return base_expected_catalog(
             project,
             role="test",

--- a/tests/functional/adapter/test_docs.py
+++ b/tests/functional/adapter/test_docs.py
@@ -51,7 +51,7 @@ class TestDocsGenerate(BaseDocsGenerate):
     """
 
     @pytest.fixture(scope="class")
-    def expected_catalog(self, project):
+    def expected_catalog(self, project, profile_user):
         return base_expected_catalog(
             project,
             role="test",

--- a/tests/functional/adapter/test_docs.py
+++ b/tests/functional/adapter/test_docs.py
@@ -15,6 +15,17 @@ model_sql = """
 select 1 as id
 """
 
+iceberg_model_sql = """
+{{
+    config(
+        materialized="table",
+        table_type="iceberg",
+        post_hook="alter table model drop column to_drop"
+    )
+}}
+select 1 as id, 'to_drop' as to_drop
+"""
+
 override_macros_sql = """
 {% macro get_catalog_relations(information_schema, relations) %}
     {{ return(adapter.get_catalog_by_relations(information_schema, relations)) }}
@@ -43,7 +54,6 @@ def custom_verify_catalog_athena(project, expected_catalog, start_time):
             for node_key in expected_node:
                 assert node_key in found_node
                 # the value of found_node[node_key] is not exactly expected_node[node_key]
-
 
 class TestDocsGenerate(BaseDocsGenerate):
     """
@@ -88,10 +98,7 @@ class TestDocsGenerateOverride:
     def macros(self):
         return {"override_macros_sql.sql": override_macros_sql}
 
-    def test_generate_docs(
-        self,
-        project,
-    ):
+    def test_generate_docs(self, project):
         results = run_dbt(["run"])
         assert len(results) == 1
 
@@ -99,3 +106,29 @@ class TestDocsGenerateOverride:
         assert len(docs_generate._compile_results.results) == 1
         assert docs_generate._compile_results.results[0].status == RunStatus.Success
         assert docs_generate.errors is None
+
+
+class TestDocsGenerateIcebergNonCurrentColumn:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"model.sql": iceberg_model_sql}
+
+    @pytest.fixture(scope="class")
+    def macros(self):
+        return {"override_macros_sql.sql": override_macros_sql}
+
+    def test_generate_docs(self, project):
+        results = run_dbt(["run"])
+        assert len(results) == 1
+
+        docs_generate = run_dbt(["--warn-error", "docs", "generate"])
+        assert len(docs_generate._compile_results.results) == 1
+        assert docs_generate._compile_results.results[0].status == RunStatus.Success
+        assert docs_generate.errors is None
+
+        catalog_path = os.path.join(project.project_root, "target", "catalog.json")
+        assert os.path.exists(catalog_path)
+        catalog = get_artifact(catalog_path)
+        columns = catalog["nodes"]["model.test.model"]["columns"]
+        assert "to_drop" not in columns
+        assert "id" in columns

--- a/tests/functional/adapter/test_docs.py
+++ b/tests/functional/adapter/test_docs.py
@@ -55,6 +55,7 @@ def custom_verify_catalog_athena(project, expected_catalog, start_time):
                 assert node_key in found_node
                 # the value of found_node[node_key] is not exactly expected_node[node_key]
 
+
 class TestDocsGenerate(BaseDocsGenerate):
     """
     Override of BaseDocsGenerate to make it working with Athena


### PR DESCRIPTION
# Description

Remove non-current iceberg columns from catalog

## Models used to test - Optional

```
{{
    config(
        materialized="table",
        table_type="iceberg",
        post_hook="alter table model drop column to_drop"
    )
}}
select 1 as id, 'to_drop' as to_drop
```

Previously, `dbt docs generate`  command generated `catalog.json` artifact which included `to_drop` column as well, however it did not exist in current table version.
Current PR fixes this behaviour and stores in `catalog.json` file only actual columns.

## Checklist

- [x] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [x] You kept your Pull Request small and focused on a single feature or bug fix.
- [x] You added unit testing when necessary
- [x] You added functional testing when necessary
