### PR TITLE
Remove the PyPI version of core that gets installed as a sidecar for internal PyPI

### DIFF
--- a/.github/workflows/publish-internal.yml
+++ b/.github/workflows/publish-internal.yml
@@ -77,7 +77,7 @@ jobs:
         run: hatch version ${{ steps.next.outputs.internal_release_version }}+$(git rev-parse HEAD)
         working-directory: ./${{ inputs.package }}
       - name: "Remove dbt-core from build requirements"
-        run: sed -i "" -e "/dbt-core[<>~=]/d" ./pyproject.toml
+        run: sed -i "/dbt-core[<>~=]/d" ./pyproject.toml
         working-directory: ./${{ inputs.package }}
       - run: |
           export HATCH_INDEX_USER=${{ secrets.AWS_USER }}

--- a/.github/workflows/publish-internal.yml
+++ b/.github/workflows/publish-internal.yml
@@ -72,6 +72,7 @@ jobs:
           versions_published: ${{ steps.published.outputs.versions }}
       - run: |
           hatch version ${{ steps.next.outputs.internal_release_version }}+$(git rev-parse HEAD)
+          sed -i "/dbt-core[>=~]=/d" "pyproject.toml"
           hatch build --clean
           hatch run build:check-all
         working-directory: ./${{ inputs.package }}

--- a/.github/workflows/publish-internal.yml
+++ b/.github/workflows/publish-internal.yml
@@ -54,7 +54,8 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       - id: package
         run: |
-          hatch version release  # strip the pre-release off since we don't use that internally
+          # strip the pre-release off to find all iterations of this patch
+          hatch version release
           echo "version=$(hatch version)" >> $GITHUB_OUTPUT
         working-directory: ./${{ inputs.package }}
       - id: published
@@ -72,11 +73,11 @@ jobs:
         with:
           version_number: ${{ steps.package.outputs.version }}
           versions_published: ${{ steps.published.outputs.versions }}
-      - run: |
-          hatch version ${{ steps.next.outputs.internal_release_version }}+$(git rev-parse HEAD)
-          sed -i "/dbt-core[>=~]=/d" "pyproject.toml"
-          hatch build --clean
-          hatch run build:check-all
+      - name: "Update version to internal PyPI format"
+        run: hatch version ${{ steps.next.outputs.internal_release_version }}+$(git rev-parse HEAD)
+        working-directory: ./${{ inputs.package }}
+      - name: "Remove dbt-core from build requirements"
+        run: sed -i "/dbt-core[>=~]=/d" "./pyproject.toml"
         working-directory: ./${{ inputs.package }}
       - run: |
           export HATCH_INDEX_USER=${{ secrets.AWS_USER }}
@@ -93,5 +94,7 @@ jobs:
             --output text \
             --query repositoryEndpoint)
 
+          hatch build --clean
+          hatch run build:check-all
           hatch publish
         working-directory: ./${{ inputs.package }}

--- a/.github/workflows/publish-internal.yml
+++ b/.github/workflows/publish-internal.yml
@@ -53,7 +53,9 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       - id: package
-        run: echo "version=$(hatch version)" >> $GITHUB_OUTPUT
+        run: |
+          hatch version release  # strip the pre-release off since we don't use that internally
+          echo "version=$(hatch version)" >> $GITHUB_OUTPUT
         working-directory: ./${{ inputs.package }}
       - id: published
         run: |

--- a/.github/workflows/publish-internal.yml
+++ b/.github/workflows/publish-internal.yml
@@ -77,7 +77,7 @@ jobs:
         run: hatch version ${{ steps.next.outputs.internal_release_version }}+$(git rev-parse HEAD)
         working-directory: ./${{ inputs.package }}
       - name: "Remove dbt-core from build requirements"
-        run: sed -i "/dbt-core[>=~]=/d" "./pyproject.toml"
+        run: sed -i "" -e "/dbt-core[<>~=]/d" ./pyproject.toml
         working-directory: ./${{ inputs.package }}
       - run: |
           export HATCH_INDEX_USER=${{ secrets.AWS_USER }}

--- a/.github/workflows/publish-internal.yml
+++ b/.github/workflows/publish-internal.yml
@@ -74,7 +74,9 @@ jobs:
           version_number: ${{ steps.package.outputs.version }}
           versions_published: ${{ steps.published.outputs.versions }}
       - name: "Update version to internal PyPI format"
-        run: hatch version ${{ steps.next.outputs.internal_release_version }}+$(git rev-parse HEAD)
+        run: |
+          VERSION=${{ steps.next.outputs.internal_release_version }}+$(git rev-parse HEAD)
+          tee <<< "version = \"$VERSION\"" ./src/dbt/adapters/athena/__version__.py
         working-directory: ./${{ inputs.package }}
       - name: "Remove dbt-core from build requirements"
         run: sed -i "/dbt-core[<>~=]/d" ./pyproject.toml


### PR DESCRIPTION
# Description

The PyPI version of `dbt-core` is colliding with `main` during the Cloud build. Remove it since we declare it explicitly in Cloud when loading all adapters.

## Checklist

- [x] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [x] You kept your Pull Request small and focused on a single feature or bug fix.
- [x] You added unit testing when necessary
- [x] You added functional testing when necessary
