### PR TITLE
Pass secrets to publish internal for AWS CLI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,6 +45,7 @@ jobs:
     with:
       deploy-to: ${{ inputs.deploy-to }}
       branch: ${{ inputs.branch }}
+    secrets: inherit
 
   publish-pypi:
     if: ${{ inputs.pypi-public == true }}


### PR DESCRIPTION
# Description

The reusable workflow `publish-internal.yml` needs access to secrets to setup AWS CLI.

## Checklist

- [x] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [x] You kept your Pull Request small and focused on a single feature or bug fix.
- [x] You added unit testing when necessary
- [x] You added functional testing when necessary