### PR TITLE
add unique temp table suffix for iceberg tables

### DIFF
--- a/dbt-athena/src/dbt/include/athena/macros/materializations/models/incremental/incremental.sql
+++ b/dbt-athena/src/dbt/include/athena/macros/materializations/models/incremental/incremental.sql
@@ -23,7 +23,7 @@
   {% if unique_tmp_table_suffix == True and table_type == 'iceberg' %}
     {% set tmp_table_suffix = adapter.generate_unique_temporary_table_suffix() %}
   {% endif %}
-  
+
   {% set old_tmp_relation = adapter.get_relation(identifier=target_relation.identifier ~ tmp_table_suffix,
                                              schema=schema,
                                              database=database) %}

--- a/dbt-athena/src/dbt/include/athena/macros/materializations/models/incremental/incremental.sql
+++ b/dbt-athena/src/dbt/include/athena/macros/materializations/models/incremental/incremental.sql
@@ -20,6 +20,10 @@
     {% set tmp_table_suffix = '__dbt_tmp' %}
   {% endif %}
 
+  {% if unique_tmp_table_suffix == True and table_type == 'iceberg' %}
+    {% set tmp_table_suffix = adapter.generate_unique_temporary_table_suffix() %}
+  {% endif %}
+  
   {% set old_tmp_relation = adapter.get_relation(identifier=target_relation.identifier ~ tmp_table_suffix,
                                              schema=schema,
                                              database=database) %}


### PR DESCRIPTION
# Description

This PR solve a issue #688 
The current configuration for iceberg tables uses the same name for all temporary tables, so you cannot run multiple concurrent runs of the same model (airflow backfill)


## Checklist

- [x] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [x] You kept your Pull Request small and focused on a single feature or bug fix.
- [x] You added unit testing when necessary
- [x] You added functional testing when necessary
