### PR TITLE
Replace environment variables with string literals in workflow defaults

### DIFF
--- a/.github/workflows/_integration-tests.yml
+++ b/.github/workflows/_integration-tests.yml
@@ -18,11 +18,11 @@ on:
             os:
                 description: "Choose the OS to test against"
                 type: string
-                default: ${{ vars.DEFAULT_RUNNER }}
+                default: "ubuntu-22.04"
             python-version:
                 description: "Choose the Python version to test against"
                 type: string
-                default: ${{ vars.DEFAULT_PYTHON_VERSION }}
+                default: "3.9"
     workflow_dispatch:
         inputs:
             package:
@@ -40,7 +40,7 @@ on:
             os:
                 description: "Choose the OS to test against"
                 type: string
-                default: ${{ vars.DEFAULT_RUNNER }}
+                default: "ubuntu-22.04"
             python-version:
                 description: "Choose the Python version to test against"
                 type: choice


### PR DESCRIPTION
GitHub does not support using environment variables as input defaults.

## Checklist

- [x] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [x] You kept your Pull Request small and focused on a single feature or bug fix.
- [x] You added unit testing when necessary
- [x] You added functional testing when necessary