### PR TITLE
fix:Create non partitioned staging table in s3 path configured as part of s3_tmp_table_dir

### DIFF
--- a/dbt-athena/src/dbt/include/athena/macros/materializations/models/table/create_table_as.sql
+++ b/dbt-athena/src/dbt/include/athena/macros/materializations/models/table/create_table_as.sql
@@ -162,7 +162,7 @@
     {%- endif -%}
 
     {%- do log('CREATE NON-PARTIONED STAGING TABLE: ' ~ tmp_relation) -%}
-    {%- do run_query(create_table_as(temporary, tmp_relation, compiled_code, language, true)) -%}
+    {%- do run_query(create_table_as(True, tmp_relation, compiled_code, language, true)) -%}
 
     {% set partitions_batches = get_partition_batches(sql=tmp_relation, as_subquery=False) %}
     {% do log('BATCHES TO PROCESS: ' ~ partitions_batches | length) %}

--- a/dbt-athena/tests/functional/adapter/test_temporary_table_s3_path.py
+++ b/dbt-athena/tests/functional/adapter/test_temporary_table_s3_path.py
@@ -1,0 +1,87 @@
+import pytest
+
+
+from dbt.contracts.results import RunStatus
+from dbt.tests.util import run_dbt
+import json
+
+import logging
+
+logging.basicConfig(level=logging.DEBUG)
+logger = logging.getLogger("dbt_test")
+
+models__tmp_s3_path_sql = """
+{{ config(
+        materialized='incremental',
+        incremental_strategy='merge',
+        partitioned_by=['dt'],
+        unique_key=['date_key'],
+        force_batch='true',
+        table_type='iceberg',
+        s3_data_naming='schema_table'
+    )
+}}
+
+
+SELECT 1 as date_key, 1 as id, '2022-01-01' AS dt
+union all
+SELECT 2, 2, '2022-01-02'
+"""
+
+
+class TestTmpTableS3Path:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"temporary_table_s3_path.sql": models__tmp_s3_path_sql}
+
+    @staticmethod
+    def extract_segment(input_string):
+        # Define the prefix to split on
+        prefix = "models/"
+
+        if prefix in input_string:
+            # Split the string on the prefix
+            _, after_prefix = input_string.split(prefix, 1)
+            # Split the remaining string on "/" and return the first part
+            return after_prefix.split("/", 1)[0]
+        return None
+
+    @staticmethod
+    def extract_s3_path_folder_name(dbt_run_capsys_output: str) -> str:
+        result = None
+        for events_msg in dbt_run_capsys_output.split("\n")[1:]:
+            base_msg_data = None
+            try:
+                base_msg_data = json.loads(events_msg).get("data")
+            except json.JSONDecodeError:
+                pass
+            """s3_data_dir will be stored in data folder and
+               s3_tmp_table_dir will be stored in temporary folder
+               With the code change now tmp table should be stored in temporary folder"""
+            if base_msg_data:
+                base_msg = base_msg_data.get("base_msg")
+                if "is stored in" in str(base_msg):
+                    result = TestTmpTableS3Path.extract_segment(base_msg)
+                    return result
+
+    def test__temporary_table_s3_path(self, project, capsys):
+        relation_name = "temporary_table_s3_path"
+        model_run = run_dbt(
+            [
+                "--debug",
+                "--log-format",
+                "json",
+                "run",
+                "--select",
+                relation_name,
+            ]
+        )
+
+        model_run_result = model_run.results[0]
+
+        assert model_run_result.status == RunStatus.Success
+
+        out, _ = capsys.readouterr()
+        s3_folder_name = TestTmpTableS3Path.extract_s3_path_folder_name(out)
+
+        assert s3_folder_name == "temporary"


### PR DESCRIPTION
# Description

<!--- In **create_table_as.sql** there is a function **create_table_as_with_partitions** which creates non-partitioned staging table and inserts into partitioned target table in batches. But  non-partitioned staging table is created in s3_data_dir path. Since this is temporary table this should be created in the path configured as part of s3_tmp_table_dir.

We do not have access to drop target tables which are created in datalake. We have capability to drop temporary tables if these tables are created in s3_tmp_table_dir because we create all temporary tables in our AWS account. Related chat is here https://getdbt.slack.com/archives/C013MLFR7BQ/p1736430731459869 -->

<!--- Add resolve #issue-number in case you resolve an open issue -->

## Models used to test - Optional
<!--- Tested model as part of this integration test test_temporary_table_s3_path.py
I have _.env_ file where i configured 
**DBT_TEST_ATHENA_S3_STAGING_DIR=s3://my-bucket/models/data/
DBT_TEST_ATHENA_S3_TMP_TABLE_DIR=s3://my-bucket/models/temporary/**

As part of this test, captured dbt logs with s3 path and asserted if table's s3 path is created in folder named temporary or not. If this change was not done, the temporary table **__tmp_not_partitioned** would have been created in data folder.
 -->

## Checklist

- [ ] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [ ] You kept your Pull Request small and focused on a single feature or bug fix.
- [ ] You added unit testing when necessary
- [ ] You added functional testing when necessary
